### PR TITLE
vv修正リリース

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          yarn config set version-git-message "%s"
           yarn version --new-version ${{ steps.bump-semver.outputs.new_version }}
           git push
 


### PR DESCRIPTION
```release_note
## Bug Fixes

- #31 `yarn version` のコミットメッセージが `vv1.0.0` のようになってしまうのを修正
```