### PR TITLE
リリースバージョン事前通知 リリース

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 <!-- For Release PR -->
+<!-- release_note コードブロックの内容は GitHub Actions によりリリースノートへ反映されます -->
 ## Release Note
 
 ```release_note

--- a/.github/workflows/release-notice.yml
+++ b/.github/workflows/release-notice.yml
@@ -1,0 +1,40 @@
+name: Release version prior notice
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - labeled
+
+jobs:
+  release-notice:
+    name: Release notice
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-ecosystem/action-release-label@v1
+        id: release-label
+        if: ${{ startsWith(github.event.label.name, 'release/') }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          semver_only: true
+
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: ${{ steps.release-label.outputs.level }}
+
+      - uses: actions-ecosystem/action-create-comment@v1
+        if: ${{ steps.bump-semver.outputs.new_version != null }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            This PR will update [${{ github.repository }}](https://github.com/${{ github.repository }}) from [${{ steps.get-latest-tag.outputs.tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get-latest-tag.outputs.tag }}) to ${{ steps.bump-semver.outputs.new_version }} :rocket:
+
+            If this update isn't as you expected, you may want to change or remove the *release label*.


### PR DESCRIPTION
<!-- For Release PR -->
<!-- release_note コードブロックの内容は GitHub Actions によりリリースノートへ反映されます -->
## Release Note

```release_note
## What's new

- #40 リリース時に事前にバージョンをコメントする
```