### PR TITLE
workflow_run を re-run したらどうなるか

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,19 @@
 name: Manually Triggered Deploy
 
 on: 
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Release"
+    branches:
+      - "main"
+    types:
+      - completed
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - name: Get latest tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release and Deploy
+name: Release
 
 on:
   push:
@@ -99,27 +99,3 @@ jobs:
           pr_body: "${{ steps.bump-semver.outputs.new_version }} がリリースされました。 develop ブランチをこのリリースに同期します。"
           pr_label: "automated"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy:
-    name: Deploy
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get latest tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
-        with:
-          semver_only: true
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.get-latest-tag.outputs.tag }}
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          version: '314.0.0'
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-      - id: format
-        run: echo "::set-output name=version::`echo ${{ steps.get-latest-tag.outputs.tag }} | sed 's/\./-/g'`"
-      - run: gcloud app deploy --quiet --version ${{ steps.format.outputs.version }}


### PR DESCRIPTION
service account の権限を削ったのでデプロイがこけるはず、それを re-run するとどうなるか

<!-- For Release PR -->
<!-- release_note コードブロックの内容は GitHub Actions によりリリースノートへ反映されます -->
## Release Note

```release_note
## What's new

- release と deploy の分離
```