### PR TITLE
バージョン予告コメントの役割を変更

### DIFF
--- a/.github/workflows/notify-release-version.yml
+++ b/.github/workflows/notify-release-version.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            This PR will update [${{ github.repository }}](https://github.com/${{ github.repository }}) from [${{ steps.get-latest-tag.outputs.tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get-latest-tag.outputs.tag }}) to ${{ steps.bump-semver.outputs.new_version }} :rocket:
+            release ラベルが変更されました。
+            この PR は [${{ github.repository }}](https://github.com/${{ github.repository }}) を [${{ steps.get-latest-tag.outputs.tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get-latest-tag.outputs.tag }}) から ${{ steps.bump-semver.outputs.new_version }} へ更新します :up:
 
-            If this update isn't as you expected, you may want to change or remove the *release label*.
+            この更新が期待どおりでないときは、 release ラベルを変更または削除すると良いかもしれません。


### PR DESCRIPTION
人間がリリースラベルを変更したときのみ発火する。文面を調整